### PR TITLE
#18 design : 예약 확인 페이지 모바일 레이아웃 디자인 수정 최종

### DIFF
--- a/src/components/DetailedHotelInfo.tsx
+++ b/src/components/DetailedHotelInfo.tsx
@@ -20,12 +20,15 @@ function DetailedHotelInfo({ hotelName, occupancy }: HotelsInfo) {
       <Image src={hotelImage} alt="호텔 방 내부 사진" />
       <DetailBox>
         <HotelInformation>
+          <StyledGrade>5.0성급</StyledGrade>
           <HotelName>{hotelName}</HotelName>
           <GuestInformation>
             기준 {occupancy.base}인 | 최대 {occupancy.max}인
           </GuestInformation>
         </HotelInformation>
-        <ReservationButton type="button">예약 취소</ReservationButton>
+        <ButtonBox>
+          <ReservationButton type="button">예약 취소</ReservationButton>
+        </ButtonBox>
       </DetailBox>
     </DetailBlock>
   );
@@ -35,10 +38,14 @@ export default DetailedHotelInfo;
 
 const DetailBlock = styled.article`
   display: flex;
-  /* width: 60vw;
-  min-width: 768px; */
   width: 100%;
+  margin-bottom: 10px;
+  border: 1px solid #f3f3f3;
   background-color: white;
+  transition: all 0.5s;
+  :hover {
+    box-shadow: 2px 3px 5px 5px #f3f3f3;
+  }
 `;
 
 const DetailBox = styled.section`
@@ -46,14 +53,21 @@ const DetailBox = styled.section`
   display: flex;
   flex-direction: column;
   width: 60%;
+  @media (max-width: 480px) {
+    width: 90%;
+    margin: 0 auto;
+  }
 `;
 
 const Image = styled.img`
-  width: 245px;
-  height: 130px;
+  width: 30%;
   border-radius: 4px;
-  margin: 30px;
+  margin: 30px 20px;
   object-fit: cover;
+
+  @media (max-width: 480px) {
+    display: none;
+  }
 `;
 
 const HotelInformation = styled.div`
@@ -62,11 +76,24 @@ const HotelInformation = styled.div`
   margin-top: 30px;
 `;
 
+const StyledGrade = styled.div`
+  width: max-content;
+  margin-bottom: 10px;
+  border: 1px solid black;
+  border-radius: 5px;
+  padding: 4px 7px;
+  font-size: 1rem;
+  box-shadow: 0 1px 1px 0;
+  @media screen and (max-width: 480px) {
+    font-size: 0.8rem;
+  }
+`;
+
 const HotelName = styled.h2`
   color: black;
-  font-size: 16px;
+  font-size: 1.5rem;
   font-weight: 700;
-  margin-bottom: 30px;
+  margin-bottom: 10px;
 `;
 
 const GuestInformation = styled.p`
@@ -74,16 +101,20 @@ const GuestInformation = styled.p`
   font-size: 12px;
 `;
 
+const ButtonBox = styled.div`
+  display: flex;
+  justify-content: flex-end;
+  align-items: flex-end;
+  height: 100%;
+`;
+
 const ReservationButton = styled.button`
   display: inline;
-  position: absolute;
-  bottom: 0;
-  right: 0;
-  min-width: 106px;
+  width: 106px;
   height: 32px;
-  margin: 30px;
+  margin: 30px 20px;
   border-radius: 4px;
   color: white;
   background-color: ${palette.pointColor};
-  cursor: pointer;
+  /* cursor: pointer; */
 `;

--- a/src/pages/statusPage/StatusPage.tsx
+++ b/src/pages/statusPage/StatusPage.tsx
@@ -74,6 +74,7 @@ const StatusContainer = styled.main`
 const ListContainer = styled.article`
   flex: 2;
   width: 100%;
+  overflow-x: hidden;
   overflow-y: auto;
 
   @media (max-width: 480px) {

--- a/src/pages/statusPage/components/ReservationList.tsx
+++ b/src/pages/statusPage/components/ReservationList.tsx
@@ -92,7 +92,7 @@ const BasicBlock = styled.section`
   flex-direction: column;
   justify-content: center;
   align-items: center;
-  background-color: ${palette.backgroundColor};
+  background-color: white;
 `;
 
 const ReservationListBlock = styled(BasicBlock)`


### PR DESCRIPTION
## 🧑‍💻 PR 내용
- 예약 확인 페이지 레이아웃 통일성 증가, 

## 📸 스크린샷
![statusmobile2](https://user-images.githubusercontent.com/20578093/183100983-176a51ba-cb4d-493f-9160-c3c45ab82a28.gif)

## 🧐 논의할 점
- 로컬 저장소 관련 기능 추가가 필요합니다
